### PR TITLE
fix: declare Apache-2.0 in pyproject.toml to match LICENSE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Bidirectional audio bridge between SIP/PJSUA2 and AI realtime voice services"
 readme = "README.md"
 requires-python = ">=3.12"
-license = {text = "GPL-2.0"}
+license = {text = "Apache-2.0"}
 authors = [
     {name = "SIP-to-AI Team", email = "team@example.com"}
 ]


### PR DESCRIPTION
## Summary
- Update `pyproject.toml` `project.license` from `GPL-2.0` to `Apache-2.0` so package metadata matches the `LICENSE` file and `README.md`, both of which declare Apache License 2.0.

## Test plan
- [x] `pyproject.toml` line 7 now reads `license = {text = "Apache-2.0"}`
- [x] `LICENSE` (Apache 2.0) and `README.md` ("Apache License 2.0") are unchanged and now consistent with metadata
- [x] Reviewer: confirm Apache-2.0 is the intended license

Fixes #2