### PR TITLE
fix(gemini): use realtimeInput.audio Blob; support gemini-3.1-flash-live-preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,7 @@ DEEPGRAM_LLM_MODEL=gpt-4o-mini  # LLM for agent: gpt-4o-mini, gpt-4o, etc.
 # Gemini Live Configuration (when AI_VENDOR=gemini)
 # Get API key from: https://aistudio.google.com/apikey
 GEMINI_API_KEY=your_gemini_api_key_here
-GEMINI_MODEL=gemini-2.5-flash-native-audio-preview-12-2025  # Gemini 2.5 Flash with native audio
+GEMINI_MODEL=gemini-3.1-flash-live-preview  # Any Live API model (also: gemini-2.5-flash-native-audio-preview-12-2025)
 GEMINI_VOICE=Puck  # Voice: Puck, Charon, Kore, Fenrir, Aoede
 
 # xAI Grok Voice Configuration (when AI_VENDOR=grok)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This project:
 **SIP-to-AI** — stream RTP audio from **FreeSWITCH / OpenSIPS / Asterisk** directly to **end-to-end realtime voice models**:
 - ✅ **OpenAI Realtime API** (`gpt-realtime-2`)
 - ✅ **Deepgram Voice Agent**
-- ✅ **Gemini Live** (Gemini 2.5 Flash)
+- ✅ **Gemini Live** (`gemini-3.1-flash-live-preview`, Gemini 2.5 Flash)
 - ✅ **xAI Grok Voice** (grok-voice-think-fast-1.0)
 
 Simple passthrough bridge: **SIP (G.711 μ-law @ 8kHz)** ↔ **AI voice models**. OpenAI, Deepgram, and Grok support native G.711, Gemini requires PCM16 resampling (8kHz ↔ 16kHz/24kHz).
@@ -178,6 +178,7 @@ sequenceDiagram
 - WebSocket: `wss://generativelanguage.googleapis.com/ws/...BidiGenerateContent`
 - Audio format: PCM16 (input @ 16kHz, output @ 24kHz)
 - Resampling: 8kHz SIP ↔ 16kHz/24kHz Gemini (handled internally)
+- Uplink uses `realtimeInput.audio` Blob (the deprecated `mediaChunks` field is rejected by newer models such as `gemini-3.1-flash-live-preview` with WebSocket close 1007)
 - Settings: model, voice, system instructions
 
 **`GrokVoiceClient`** (`app/ai/grok_voice.py`)
@@ -220,9 +221,11 @@ Set `AI_VENDOR=gemini` in `.env`:
 AI_VENDOR=gemini
 GEMINI_API_KEY=your-key-here
 AGENT_PROMPT_FILE=agent_prompt.yaml
-GEMINI_MODEL=gemini-2.5-flash-native-audio-preview-12-2025
+GEMINI_MODEL=gemini-3.1-flash-live-preview
 GEMINI_VOICE=Puck
 ```
+
+Supported models (any Live API model works): `gemini-3.1-flash-live-preview` (default), `gemini-2.5-flash-native-audio-preview-12-2025`.
 
 Available voices: `Puck`, `Charon`, `Kore`, `Fenrir`, `Aoede`
 

--- a/app/ai/gemini_live.py
+++ b/app/ai/gemini_live.py
@@ -43,7 +43,7 @@ class GeminiLiveClient(AiDuplexBase):
     def __init__(
         self,
         api_key: Optional[str] = None,
-        model: str = "gemini-2.5-flash-native-audio-preview-12-2025",
+        model: str = "gemini-3.1-flash-live-preview",
         voice: str = "Puck",
         instructions: str = "You are a helpful assistant.",
         greeting: Optional[str] = None
@@ -187,13 +187,15 @@ class GeminiLiveClient(AiDuplexBase):
                 expected_output=640  # 320 samples * 2 bytes @ 16kHz
             )
 
-        # Send realtime input message with base64-encoded audio
+        # Send realtime input message with base64-encoded audio.
+        # Use the `audio` Blob field; `mediaChunks` is deprecated and rejected
+        # (WebSocket close 1007) by newer Live API models.
         message = {
             "realtimeInput": {
-                "mediaChunks": [{
+                "audio": {
                     "mimeType": "audio/pcm;rate=16000",
                     "data": base64.b64encode(pcm16_16k).decode("utf-8")
-                }]
+                }
             }
         }
 

--- a/app/config.py
+++ b/app/config.py
@@ -112,7 +112,7 @@ class AIConfig:
 
     # Gemini Live Configuration
     gemini_api_key: str = ""
-    gemini_model: str = "gemini-2.5-flash-native-audio-preview-12-2025"  # Model with Live API support
+    gemini_model: str = "gemini-3.1-flash-live-preview"  # Model with Live API support
     gemini_voice: str = "Puck"  # Voice: Puck, Charon, Kore, Fenrir, Aoede
 
     # xAI Grok Voice Configuration
@@ -175,7 +175,7 @@ class Config:
             deepgram_speak_model=os.getenv("DEEPGRAM_SPEAK_MODEL", "aura-asteria-en"),
             deepgram_llm_model=os.getenv("DEEPGRAM_LLM_MODEL", "gpt-4o-mini"),
             gemini_api_key=os.getenv("GEMINI_API_KEY", ""),
-            gemini_model=os.getenv("GEMINI_MODEL", "gemini-2.5-flash-native-audio-preview-12-2025"),
+            gemini_model=os.getenv("GEMINI_MODEL", "gemini-3.1-flash-live-preview"),
             gemini_voice=os.getenv("GEMINI_VOICE", "Puck"),
             grok_api_key=os.getenv("XAI_API_KEY", ""),
             grok_ws_endpoint=os.getenv("GROK_WS_ENDPOINT", "wss://api.x.ai/v1/realtime"),

--- a/tests/test_gemini_live.py
+++ b/tests/test_gemini_live.py
@@ -1,0 +1,67 @@
+"""Unit tests for GeminiLiveClient uplink message format."""
+
+import base64
+import json
+
+import pytest
+
+
+class _FakeWebSocket:
+    """Minimal stand-in for websockets client used in tests."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.closed = False
+
+    async def send(self, message: str) -> None:
+        if self.closed:
+            raise ConnectionError("closed")
+        self.sent.append(message)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class TestGeminiUplink:
+    """Tests for send_pcm16_8k message format."""
+
+    @pytest.mark.asyncio
+    async def test_send_pcm16_8k_uses_audio_blob_not_media_chunks(self) -> None:
+        """Uplink must use realtimeInput.audio Blob; mediaChunks is deprecated
+        and rejected by newer Live API models with WebSocket close 1007."""
+        from app.ai.gemini_live import GeminiLiveClient
+
+        client = GeminiLiveClient(api_key="k")
+        ws = _FakeWebSocket()
+        client._ws = ws  # type: ignore[assignment]
+        client._connected = True
+
+        # 320 bytes PCM16 silence @ 8kHz = 20ms
+        await client.send_pcm16_8k(b"\x00" * 320)
+
+        assert len(ws.sent) == 1
+        ri = json.loads(ws.sent[0])["realtimeInput"]
+        assert "mediaChunks" not in ri
+        assert ri["audio"]["mimeType"] == "audio/pcm;rate=16000"
+        # 8kHz -> 16kHz doubles samples: 320 bytes -> 640 bytes
+        decoded = base64.b64decode(ri["audio"]["data"])
+        assert len(decoded) == 640
+
+    @pytest.mark.asyncio
+    async def test_send_pcm16_8k_validates_frame_size(self) -> None:
+        from app.ai.gemini_live import GeminiLiveClient
+
+        client = GeminiLiveClient(api_key="k")
+        client._ws = _FakeWebSocket()  # type: ignore[assignment]
+        client._connected = True
+
+        with pytest.raises(ValueError, match="320"):
+            await client.send_pcm16_8k(b"\x00" * 100)
+
+    @pytest.mark.asyncio
+    async def test_send_pcm16_8k_raises_when_not_connected(self) -> None:
+        from app.ai.gemini_live import GeminiLiveClient
+
+        client = GeminiLiveClient(api_key="k")
+        with pytest.raises(ConnectionError):
+            await client.send_pcm16_8k(b"\x00" * 320)


### PR DESCRIPTION
The uplink sent audio via the deprecated realtimeInput.mediaChunks field, which newer Live API models (e.g. gemini-3.1-flash-live-preview) reject with WebSocket close 1007, after which every frame raised "Not connected" (369x in the latest log). Switch to the realtimeInput.audio Blob field and make gemini-3.1-flash-live-preview the default model across config, client, README, and .env.example. Add tests covering the uplink message format.