### PR TITLE
Added 60dB integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,8 +20,16 @@ OPENAI_MODEL=gpt-realtime-2
 # Deepgram Configuration (when AI_VENDOR=deepgram)
 DEEPGRAM_API_KEY=your_deepgram_api_key_here
 DEEPGRAM_LISTEN_MODEL=nova-2  # STT model: nova-2, nova-3
-DEEPGRAM_SPEAK_MODEL=aura-asteria-en  # TTS voice: aura-asteria-en, aura-luna-en, etc.
+DEEPGRAM_SPEAK_MODEL=aura-asteria-en  # TTS voice (only used when SPEAK_PROVIDER=deepgram)
 DEEPGRAM_LLM_MODEL=gpt-4o-mini  # LLM for agent: gpt-4o-mini, gpt-4o, etc.
+
+# Speak provider: who renders the Deepgram agent's voice.
+#   deepgram -> built-in Aura TTS (default)
+#   60db     -> Deepgram stays the brain (STT + gpt-4o-mini + turn-taking), 60db is the voice
+SPEAK_PROVIDER=deepgram
+# 60db voice (required when SPEAK_PROVIDER=60db). List voices: uv run python scripts/list_60db_voices.py
+SIXTYDB_API_KEY=your_60db_api_key_here
+SIXTYDB_VOICE_ID=fbb75ed2-975a-40c7-9e06-38e30524a9a1  # 60db default voice
 
 # Gemini Live Configuration (when AI_VENDOR=gemini)
 # Get API key from: https://aistudio.google.com/apikey

--- a/README.md
+++ b/README.md
@@ -212,6 +212,42 @@ greeting: "Hello! How can I help you today?"
 
 Get your API key from [Deepgram Console](https://console.deepgram.com).
 
+### Use a 60db voice with the Deepgram brain (`SPEAK_PROVIDER=60db`)
+
+60db is **not** an end-to-end voice agent — it has no LLM, only speech I/O (STT, TTS, voices).
+So it cannot replace Deepgram. Instead it can be used as the **voice** of the Deepgram agent:
+Deepgram keeps doing STT + LLM (`gpt-4o-mini`) + VAD/turn-taking and emits the agent's reply
+as text (`ConversationText`); we synthesize that text with **60db TTS** (μ-law @ 8kHz) and feed
+it back to the caller. Deepgram is the brain, 60db is the mouth.
+
+```bash
+AI_VENDOR=deepgram
+DEEPGRAM_API_KEY=your-deepgram-key
+DEEPGRAM_LISTEN_MODEL=nova-2
+DEEPGRAM_LLM_MODEL=gpt-4o-mini
+AGENT_PROMPT_FILE=agent_prompt.yaml
+
+# Switch the voice to 60db
+SPEAK_PROVIDER=60db
+SIXTYDB_API_KEY=sk_live_your_60db_key
+SIXTYDB_VOICE_ID=fbb75ed2-975a-40c7-9e06-38e30524a9a1
+```
+
+List the voices on your 60db account to pick a `SIXTYDB_VOICE_ID`:
+
+```bash
+uv run python scripts/list_60db_voices.py
+```
+
+**How it works:** `60db TTS WebSocket` (`wss://api.60db.ai/ws/tts`) is configured for
+`MULAW` @ 8kHz, so its audio drops straight into the existing bridge with no resampling.
+`DEEPGRAM_SPEAK_MODEL` is ignored in this mode (Deepgram's own audio is discarded).
+
+**Trade-offs:** routing the reply text out to a second service adds some latency, and you lose
+Deepgram's native barge-in timing on the spoken audio (this mode is effectively half-duplex,
+matching the existing Deepgram barge-in suppression). Use it only when you specifically want a
+60db voice/clone. Get a 60db key from [60db](https://60db.ai).
+
 
 ## Gemini Live Setup
 

--- a/app/ai/deepgram_agent.py
+++ b/app/ai/deepgram_agent.py
@@ -12,13 +12,16 @@ API Documentation:
 
 import asyncio
 import json
-from typing import AsyncIterator, Dict, Optional
+from typing import TYPE_CHECKING, AsyncIterator, Dict, Optional
 
 import structlog
 import websockets
 from websockets.client import WebSocketClientProtocol
 
 from app.ai.duplex_base import AiDuplexBase, AiEvent, AiEventType
+
+if TYPE_CHECKING:
+    from app.ai.sixtydb_tts import SixtyDBTTSClient
 
 
 class DeepgramAgentClient(AiDuplexBase):
@@ -34,7 +37,10 @@ class DeepgramAgentClient(AiDuplexBase):
         speak_model: str = "aura-asteria-en",
         llm_model: str = "gpt-4o-mini",
         instructions: str = "You are a helpful voice assistant.",
-        greeting: Optional[str] = None
+        greeting: Optional[str] = None,
+        speak_provider: str = "deepgram",
+        sixtydb_api_key: Optional[str] = None,
+        sixtydb_voice_id: Optional[str] = None,
     ) -> None:
         """Initialize Deepgram Voice Agent client.
 
@@ -44,10 +50,14 @@ class DeepgramAgentClient(AiDuplexBase):
             frame_ms: Frame duration in milliseconds
             audio_format: Audio format (mulaw for μ-law encoding)
             listen_model: STT model (nova-2, nova-3)
-            speak_model: TTS voice model
+            speak_model: TTS voice model (used only when speak_provider="deepgram")
             llm_model: LLM model for agent
             instructions: Agent instructions/system prompt
             greeting: Optional greeting message spoken at call start
+            speak_provider: Who renders the agent's voice: "deepgram" (built-in
+                Aura TTS) or "60db" (Deepgram stays the brain, 60db is the voice).
+            sixtydb_api_key: 60db API key (required when speak_provider="60db")
+            sixtydb_voice_id: 60db voice UUID (optional; defaults to 60db default)
         """
         # Initialize base class (same pattern as OpenAI client)
         super().__init__(sample_rate=sample_rate, frame_ms=frame_ms)
@@ -62,6 +72,23 @@ class DeepgramAgentClient(AiDuplexBase):
         self._llm_model = llm_model
         self._instructions = instructions
         self._greeting = greeting
+
+        # Speak provider: "deepgram" (built-in Aura) or "60db" (external voice).
+        self._speak_provider = speak_provider
+        self._sixtydb: Optional["SixtyDBTTSClient"] = None
+        if self._speak_provider == "60db":
+            if not sixtydb_api_key:
+                raise ValueError("60db API key is required when speak_provider='60db'")
+            # Imported lazily to keep the default Deepgram path dependency-free.
+            from app.ai.sixtydb_tts import SixtyDBTTSClient
+
+            self._sixtydb = SixtyDBTTSClient(
+                api_key=sixtydb_api_key,
+                voice_id=sixtydb_voice_id,
+                sample_rate=sample_rate,
+                on_audio=self._enqueue_agent_audio,
+                on_flush_complete=self._on_sixtydb_flush_done,
+            )
 
         # Override frame size for mulaw (1 byte per sample, same as G.711)
         if audio_format == "mulaw":
@@ -133,6 +160,18 @@ class DeepgramAgentClient(AiDuplexBase):
             )
             self._logger.info("Started KeepAlive task")
 
+            # If 60db is the voice, connect it and have IT speak the greeting.
+            # (Deepgram remains the brain: STT + LLM + turn-taking.)
+            if self._sixtydb is not None:
+                await self._sixtydb.connect()
+                self._logger.info("60db TTS connected as speak provider")
+                if self._greeting:
+                    # speak() returns immediately; audio streams in via callback.
+                    await self._sixtydb.speak(self._greeting)
+                else:
+                    # No greeting to produce "first audio", so unblock user audio now.
+                    self._received_first_audio = True
+
             # Emit connected event
             await self._event_queue.put(AiEvent(
                 type=AiEventType.CONNECTED,
@@ -176,7 +215,9 @@ class DeepgramAgentClient(AiDuplexBase):
             }
         }
 
-        if self._greeting:
+        # When 60db is the voice, we speak the greeting ourselves via 60db so
+        # Deepgram does not auto-greet with its own (ignored) audio.
+        if self._greeting and self._speak_provider != "60db":
             agent_config["greeting"] = self._greeting
 
         config = {
@@ -231,6 +272,10 @@ class DeepgramAgentClient(AiDuplexBase):
                     await self._receive_task
                 except asyncio.CancelledError:
                     pass
+
+            # Close the 60db voice connection if in use.
+            if self._sixtydb is not None:
+                await self._sixtydb.close()
 
             await self._ws.close()
             self._ws = None
@@ -350,33 +395,53 @@ class DeepgramAgentClient(AiDuplexBase):
             ))
 
     async def _handle_binary_audio(self, audio_data: bytes) -> None:
-        """Handle binary audio message from Deepgram.
+        """Handle binary (mu-law) audio message produced by Deepgram's own TTS.
 
-        Deepgram sends binary μ-law audio in variable-size chunks (typically 960 bytes).
-        Convert to PCM16 and yield as variable-size chunk.
-
-        Frame splitting and padding is handled by AudioAdapter.feed_ai_audio().
+        When 60db is the speak provider, Deepgram's audio is ignored entirely —
+        speech is produced by 60db from ConversationText instead.
 
         Args:
             audio_data: Binary μ-law audio data from Deepgram
         """
+        if self._speak_provider == "60db":
+            return
+        await self._enqueue_agent_audio(audio_data)
+
+    async def _enqueue_agent_audio(self, audio_data: bytes) -> None:
+        """Convert mu-law agent audio to PCM16 and queue it for the bridge.
+
+        Shared by both speak providers:
+        - Deepgram's binary audio (default path)
+        - 60db's decoded audio_chunk bytes (on_audio callback)
+
+        Frame splitting/padding is handled downstream by AudioAdapter.feed_ai_audio().
+
+        Args:
+            audio_data: Binary μ-law audio data (8kHz)
+        """
         import time
         from app.utils.codec import Codec
 
-        # Mark that we've received first audio - now safe to send user audio
+        # Mark that we've received first audio - now safe to send user audio.
         if not self._received_first_audio:
             self._received_first_audio = True
             self._logger.info("Received first AI audio - enabling user audio")
 
-        # Mark agent as speaking and update timestamp
+        # Mark agent as speaking and update timestamp (drives barge-in suppression).
         self._agent_speaking = True
         self._last_agent_audio_time = time.time()
 
-        # Convert μ-law to PCM16 (variable-size chunk)
+        # Convert μ-law to PCM16 (variable-size chunk).
         pcm16_chunk = Codec.ulaw_to_pcm16(audio_data)
 
-        # Send entire chunk to AudioAdapter (it will handle frame splitting)
+        # Send entire chunk to AudioAdapter (it will handle frame splitting).
         await self._audio_queue.put(pcm16_chunk)
+
+    async def _on_sixtydb_flush_done(self) -> None:
+        """Called when 60db finishes synthesizing an utterance."""
+        # 60db has spoken the full reply; clear the speaking flag so the
+        # caller's audio is forwarded to Deepgram again (after the tail guard).
+        self._agent_speaking = False
 
     async def _handle_json_message(self, message: str) -> None:
         """Handle JSON message from Deepgram.
@@ -401,7 +466,10 @@ class DeepgramAgentClient(AiDuplexBase):
                 ))
 
             elif msg_type == "AgentAudioDone":
-                self._agent_speaking = False
+                # When 60db is the voice, Deepgram's own audio is ignored, so its
+                # "done" signal must not clear the flag — 60db's flush_completed does.
+                if self._speak_provider != "60db":
+                    self._agent_speaking = False
                 await self._event_queue.put(AiEvent(
                     type=AiEventType.TRANSCRIPT_FINAL,
                     data={"event": "agent_audio_done"}
@@ -428,8 +496,14 @@ class DeepgramAgentClient(AiDuplexBase):
                 self._logger.info("Connected to Deepgram Voice Agent")
 
             elif msg_type == "ConversationText":
-                # Log conversation for debugging (optional)
-                pass
+                # Deepgram emits the conversation transcript for both sides:
+                #   {"type": "ConversationText", "role": "assistant"|"user", "content": "..."}
+                # When 60db is the voice, the assistant's text is what we synthesize.
+                if self._speak_provider == "60db" and self._sixtydb is not None:
+                    role = data.get("role")
+                    content = data.get("content", "")
+                    if role == "assistant" and content.strip():
+                        await self._sixtydb.speak(content)
 
             elif msg_type == "History":
                 # Conversation history (optional)

--- a/app/ai/sixtydb_tts.py
+++ b/app/ai/sixtydb_tts.py
@@ -1,0 +1,240 @@
+"""60db Text-to-Speech WebSocket client (voice-only "speak" engine).
+
+This is NOT a standalone voice agent. 60db has no LLM, so it cannot listen,
+think and reply on its own. Instead it is used as the *voice* of the Deepgram
+Voice Agent:
+
+    Deepgram (STT + LLM/think + VAD/turn-taking) --emits agent text-->
+        ConversationText --> SixtyDBTTSClient.speak(text) --> mulaw audio
+            --> bridge --> caller
+
+So Deepgram is the brain and 60db is the mouth.
+
+API Documentation:
+- WebSocket: wss://api.60db.ai/ws/tts?apiKey=<API_KEY>
+- Auth: ``apiKey`` query parameter (NOT an Authorization header)
+- Audio output: MULAW @ 8kHz (telephony-native, same as Deepgram/G.711)
+- Protocol: JSON control messages; audio returned as base64 in ``audio_chunk``
+
+Connection sequence:
+1. connect -> server sends ``connection_established``
+2. client sends ``create_context`` -> server replies ``context_created``
+3. client sends ``send_text`` then ``flush_context`` to synthesize
+4. server streams ``audio_chunk`` messages, then a ``flush_completed``
+"""
+
+import asyncio
+import base64
+import json
+from typing import Awaitable, Callable, Optional
+
+import structlog
+import websockets
+from websockets.client import WebSocketClientProtocol
+
+
+class SixtyDBTTSClient:
+    """60db TTS WebSocket client: text -> mulaw @ 8kHz audio.
+
+    Audio is delivered out-of-band via the ``on_audio`` callback as raw 8kHz
+    mu-law bytes (decoded from the base64 ``audio_chunk`` field). ``on_flush_complete``
+    fires when 60db signals an utterance has been fully synthesized.
+    """
+
+    WS_URL = "wss://api.60db.ai/ws/tts"
+    # 60db's documented default voice; overridable via SIXTYDB_VOICE_ID.
+    DEFAULT_VOICE_ID = "fbb75ed2-975a-40c7-9e06-38e30524a9a1"
+
+    def __init__(
+        self,
+        api_key: str,
+        voice_id: Optional[str] = None,
+        sample_rate: int = 8000,
+        speed: float = 1.0,
+        stability: int = 50,
+        similarity: int = 75,
+        on_audio: Optional[Callable[[bytes], Awaitable[None]]] = None,
+        on_flush_complete: Optional[Callable[[], Awaitable[None]]] = None,
+    ) -> None:
+        """Initialize the 60db TTS client.
+
+        Args:
+            api_key: 60db API key (``sk_live_...``)
+            voice_id: 60db voice UUID (defaults to 60db's default voice)
+            sample_rate: Output sample rate (must be 8000 for MULAW)
+            speed: Speech rate, 0.5-2.0
+            stability: 0-100 (lower = more expressive)
+            similarity: 0-100 (voice matching fidelity)
+            on_audio: Async callback invoked with raw mu-law bytes per chunk
+            on_flush_complete: Async callback invoked when an utterance is done
+        """
+        if not api_key:
+            raise ValueError("60db API key is required")
+        if sample_rate != 8000:
+            raise ValueError(f"60db TTS (MULAW) only supports 8kHz, got: {sample_rate}")
+
+        self._api_key = api_key
+        self._voice_id = voice_id or self.DEFAULT_VOICE_ID
+        self._sample_rate = sample_rate
+        self._speed = speed
+        self._stability = stability
+        self._similarity = similarity
+        self._on_audio = on_audio
+        self._on_flush_complete = on_flush_complete
+
+        self._ws: Optional[WebSocketClientProtocol] = None
+        self._connected = False
+        # Single persistent synthesis context for the whole call.
+        self._context_id = "sip-to-ai"
+        self._context_ready = asyncio.Event()
+        self._receive_task: Optional[asyncio.Task] = None
+
+        self._logger = structlog.get_logger(__name__)
+
+    @property
+    def is_connected(self) -> bool:
+        """Whether the TTS WebSocket is connected and the context is ready."""
+        return self._connected
+
+    async def connect(self) -> None:
+        """Open the WebSocket and initialize the synthesis context."""
+        if self._connected:
+            return
+
+        url = f"{self.WS_URL}?apiKey={self._api_key}"
+        self._logger.info("Connecting to 60db TTS", url=self.WS_URL, voice_id=self._voice_id)
+
+        async with asyncio.timeout(10.0):
+            self._ws = await websockets.connect(url, open_timeout=10.0)
+
+        self._connected = True
+
+        # Start receiver first so connection_established / context_created are caught.
+        self._receive_task = asyncio.create_task(
+            self._receive_messages(), name="sixtydb-tts-receive"
+        )
+
+        await self._send_create_context()
+
+        try:
+            await asyncio.wait_for(self._context_ready.wait(), timeout=10.0)
+        except asyncio.TimeoutError:
+            self._logger.error("Timeout waiting for 60db context_created")
+            raise
+
+        self._logger.info("60db TTS ready", context_id=self._context_id)
+
+    async def _send_create_context(self) -> None:
+        """Send the create_context message that configures the voice/audio."""
+        if not self._ws:
+            return
+        msg = {
+            "create_context": {
+                "context_id": self._context_id,
+                "voice_id": self._voice_id,
+                "audio_config": {
+                    "audio_encoding": "MULAW",
+                    "sample_rate_hertz": self._sample_rate,
+                },
+                "speed": self._speed,
+                "stability": self._stability,
+                "similarity": self._similarity,
+            }
+        }
+        await self._ws.send(json.dumps(msg))
+
+    async def speak(self, text: str) -> None:
+        """Synthesize ``text`` to speech. Audio arrives via the on_audio callback.
+
+        Sends ``send_text`` followed by ``flush_context`` so 60db starts
+        streaming audio immediately for this utterance.
+        """
+        if not self._ws or not self._connected:
+            self._logger.warning("Cannot speak: 60db TTS not connected")
+            return
+        if not text or not text.strip():
+            return
+
+        await self._ws.send(
+            json.dumps({"send_text": {"context_id": self._context_id, "text": text}})
+        )
+        await self._ws.send(
+            json.dumps({"flush_context": {"context_id": self._context_id}})
+        )
+        self._logger.info("Sent text to 60db TTS", chars=len(text))
+
+    async def _receive_messages(self) -> None:
+        """Receive and dispatch JSON messages from 60db."""
+        if not self._ws:
+            return
+        try:
+            async for message in self._ws:
+                # 60db TTS communicates exclusively via JSON (audio is base64).
+                if isinstance(message, str):
+                    await self._handle_message(message)
+        except websockets.exceptions.ConnectionClosed:
+            self._logger.info("60db TTS connection closed")
+            self._connected = False
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            self._logger.error("60db TTS receive error", error=str(e))
+
+    async def _handle_message(self, message: str) -> None:
+        """Parse one JSON message and route it to the appropriate handler."""
+        try:
+            data = json.loads(message)
+        except json.JSONDecodeError:
+            self._logger.warning("60db TTS sent non-JSON message")
+            return
+
+        if "connection_established" in data:
+            info = data["connection_established"]
+            self._logger.info(
+                "60db TTS connection established",
+                workspace=info.get("workspace"),
+                credit_balance=info.get("credit_balance"),
+            )
+        elif "context_created" in data:
+            self._context_ready.set()
+        elif "audio_chunk" in data:
+            b64 = data["audio_chunk"].get("audioContent", "")
+            if b64 and self._on_audio:
+                ulaw_bytes = base64.b64decode(b64)
+                await self._on_audio(ulaw_bytes)
+        elif "flush_completed" in data:
+            if self._on_flush_complete:
+                await self._on_flush_complete()
+        elif "context_closed" in data:
+            self._logger.info("60db TTS context closed")
+        elif "error" in data:
+            err = data["error"]
+            self._logger.error("60db TTS error", message=err.get("message"))
+
+    async def close(self) -> None:
+        """Close the synthesis context and the WebSocket."""
+        if self._ws is None:
+            return
+
+        self._connected = False
+        try:
+            try:
+                await self._ws.send(
+                    json.dumps({"close_context": {"context_id": self._context_id}})
+                )
+            except Exception:
+                pass
+
+            if self._receive_task and not self._receive_task.done():
+                self._receive_task.cancel()
+                try:
+                    await self._receive_task
+                except asyncio.CancelledError:
+                    pass
+
+            await self._ws.close()
+        except Exception as e:
+            self._logger.error("Error closing 60db TTS", error=str(e))
+        finally:
+            self._ws = None
+            self._context_ready.clear()

--- a/app/config.py
+++ b/app/config.py
@@ -107,8 +107,17 @@ class AIConfig:
     # Deepgram Configuration
     deepgram_api_key: str = ""
     deepgram_listen_model: str = "nova-2"  # STT model (nova-2, nova-3)
-    deepgram_speak_model: str = "aura-asteria-en"  # TTS voice
+    deepgram_speak_model: str = "aura-asteria-en"  # TTS voice (when speak_provider=deepgram)
     deepgram_llm_model: str = "gpt-4o-mini"  # LLM model for agent
+
+    # Speak provider: who renders the Deepgram agent's voice.
+    #   "deepgram" -> built-in Aura TTS (default)
+    #   "60db"     -> Deepgram stays the brain (STT+LLM+turn-taking), 60db is the voice
+    speak_provider: Literal["deepgram", "60db"] = "deepgram"
+
+    # 60db Voice (used when speak_provider=60db)
+    sixtydb_api_key: str = ""
+    sixtydb_voice_id: str = "fbb75ed2-975a-40c7-9e06-38e30524a9a1"  # 60db default voice
 
     # Gemini Live Configuration
     gemini_api_key: str = ""
@@ -174,6 +183,11 @@ class Config:
             deepgram_listen_model=os.getenv("DEEPGRAM_LISTEN_MODEL", "nova-2"),
             deepgram_speak_model=os.getenv("DEEPGRAM_SPEAK_MODEL", "aura-asteria-en"),
             deepgram_llm_model=os.getenv("DEEPGRAM_LLM_MODEL", "gpt-4o-mini"),
+            speak_provider=os.getenv("SPEAK_PROVIDER", "deepgram").lower(),  # type: ignore
+            sixtydb_api_key=os.getenv("SIXTYDB_API_KEY", ""),
+            sixtydb_voice_id=os.getenv(
+                "SIXTYDB_VOICE_ID", "fbb75ed2-975a-40c7-9e06-38e30524a9a1"
+            ),
             gemini_api_key=os.getenv("GEMINI_API_KEY", ""),
             gemini_model=os.getenv("GEMINI_MODEL", "gemini-3.1-flash-live-preview"),
             gemini_voice=os.getenv("GEMINI_VOICE", "Puck"),

--- a/app/main.py
+++ b/app/main.py
@@ -162,13 +162,21 @@ def create_ai_client() -> AiDuplexClient:
         # Load agent configuration (required for Deepgram)
         instructions, greeting = _load_agent_config(logger)
 
+        # Validate 60db voice configuration if selected as the speak provider.
+        if config.ai.speak_provider == "60db" and not config.ai.sixtydb_api_key:
+            raise ValueError(
+                "SPEAK_PROVIDER=60db requires SIXTYDB_API_KEY to be set"
+            )
+
         logger.info(
             "Using Deepgram Voice Agent client",
             prompt_file=config.ai.agent_prompt_file,
             instructions_length=len(instructions),
             has_greeting=greeting is not None,
             greeting_preview=greeting[:50] if greeting else None,
-            instructions_preview=instructions[:100] if instructions else None
+            instructions_preview=instructions[:100] if instructions else None,
+            speak_provider=config.ai.speak_provider,
+            sixtydb_voice_id=config.ai.sixtydb_voice_id if config.ai.speak_provider == "60db" else None,
         )
 
         return DeepgramAgentClient(
@@ -180,7 +188,10 @@ def create_ai_client() -> AiDuplexClient:
             speak_model=config.ai.deepgram_speak_model,
             llm_model=config.ai.deepgram_llm_model,
             instructions=instructions,
-            greeting=greeting
+            greeting=greeting,
+            speak_provider=config.ai.speak_provider,
+            sixtydb_api_key=config.ai.sixtydb_api_key,
+            sixtydb_voice_id=config.ai.sixtydb_voice_id,
         )
 
     elif vendor == "gemini":

--- a/scripts/list_60db_voices.py
+++ b/scripts/list_60db_voices.py
@@ -1,0 +1,79 @@
+"""List the voices available to your 60db account (GET /myvoices).
+
+Use this to pick a SIXTYDB_VOICE_ID for the Deepgram-brain + 60db-voice setup.
+
+Usage:
+    uv run python scripts/list_60db_voices.py
+
+Reads SIXTYDB_API_KEY from the environment / .env.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+from dotenv import load_dotenv
+
+
+def _fetch_voices(api_key: str) -> tuple[int, dict[str, Any]]:
+    req = urllib.request.Request(
+        "https://api.60db.ai/myvoices",
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as response:
+            return response.status, json.loads(response.read().decode())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            payload = {"message": body[:500]}
+        return exc.code, payload
+
+
+def main() -> int:
+    load_dotenv()
+    api_key = os.getenv("SIXTYDB_API_KEY", "")
+    if not api_key:
+        print("SIXTYDB_API_KEY is not set (env or .env).", file=sys.stderr)
+        return 1
+
+    status, payload = _fetch_voices(api_key)
+    if status != 200 or not payload.get("success", True):
+        print(f"Request failed (HTTP {status}): {payload}", file=sys.stderr)
+        return 1
+
+    voices = payload.get("data", [])
+    if not voices:
+        print("No voices found for this account.")
+        return 0
+
+    print(f"{'voice_id':38}  {'name':24}  {'category':12}  {'model':12}  labels")
+    print("-" * 110)
+    for v in voices:
+        labels = v.get("labels", {}) or {}
+        label_str = ", ".join(
+            str(labels.get(k))
+            for k in ("language_name", "gender", "accent")
+            if labels.get(k)
+        )
+        print(
+            f"{v.get('voice_id', ''):38}  "
+            f"{(v.get('name') or ''):24.24}  "
+            f"{(v.get('category') or ''):12.12}  "
+            f"{(v.get('model') or ''):12.12}  "
+            f"{label_str}"
+        )
+
+    print("\nSet one as your voice:  SIXTYDB_VOICE_ID=<voice_id>")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_sixtydb_voice.py
+++ b/tests/test_sixtydb_voice.py
@@ -1,0 +1,166 @@
+"""Unit tests for the 60db voice (SPEAK_PROVIDER=60db) integration.
+
+Covers:
+- config wiring (SPEAK_PROVIDER / SIXTYDB_* env vars)
+- SixtyDBTTSClient message handling (create_context payload, audio_chunk decode)
+- DeepgramAgentClient routing when 60db is the speak provider
+"""
+
+import base64
+import json
+import os
+from importlib import reload
+from unittest.mock import patch
+
+import pytest
+
+from app.utils.codec import Codec
+
+
+class TestSpeakProviderConfig:
+    """SPEAK_PROVIDER / SIXTYDB_* config fields."""
+
+    def test_defaults_to_deepgram(self) -> None:
+        with patch.dict(os.environ, {"AI_VENDOR": "deepgram"}, clear=False):
+            from app import config as cfg_module
+            reload(cfg_module)
+            assert cfg_module.config.ai.speak_provider == "deepgram"
+
+    def test_sixtydb_env_overrides(self) -> None:
+        env = {
+            "AI_VENDOR": "deepgram",
+            "SPEAK_PROVIDER": "60db",
+            "SIXTYDB_API_KEY": "sk_live_test",
+            "SIXTYDB_VOICE_ID": "voice-123",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            from app import config as cfg_module
+            reload(cfg_module)
+            assert cfg_module.config.ai.speak_provider == "60db"
+            assert cfg_module.config.ai.sixtydb_api_key == "sk_live_test"
+            assert cfg_module.config.ai.sixtydb_voice_id == "voice-123"
+
+
+class TestSixtyDBTTSClient:
+    """SixtyDBTTSClient construction and message handling."""
+
+    def test_missing_api_key_raises(self) -> None:
+        from app.ai.sixtydb_tts import SixtyDBTTSClient
+        with pytest.raises(ValueError):
+            SixtyDBTTSClient(api_key="")
+
+    def test_non_8k_rejected(self) -> None:
+        from app.ai.sixtydb_tts import SixtyDBTTSClient
+        with pytest.raises(ValueError):
+            SixtyDBTTSClient(api_key="k", sample_rate=16000)
+
+    def test_create_context_payload(self) -> None:
+        from app.ai.sixtydb_tts import SixtyDBTTSClient
+
+        sent: list[str] = []
+
+        class _FakeWS:
+            async def send(self, msg: str) -> None:
+                sent.append(msg)
+
+        client = SixtyDBTTSClient(api_key="k", voice_id="voice-xyz")
+        client._ws = _FakeWS()  # type: ignore[assignment]
+
+        import asyncio
+        asyncio.run(client._send_create_context())
+
+        payload = json.loads(sent[0])["create_context"]
+        assert payload["voice_id"] == "voice-xyz"
+        assert payload["audio_config"] == {
+            "audio_encoding": "MULAW",
+            "sample_rate_hertz": 8000,
+        }
+
+    def test_audio_chunk_decoded_and_forwarded(self) -> None:
+        from app.ai.sixtydb_tts import SixtyDBTTSClient
+
+        received: list[bytes] = []
+
+        async def _on_audio(b: bytes) -> None:
+            received.append(b)
+
+        client = SixtyDBTTSClient(api_key="k", on_audio=_on_audio)
+
+        raw = b"\xff\x7f\x00\x10"
+        msg = json.dumps(
+            {"audio_chunk": {"context_id": "c", "audioContent": base64.b64encode(raw).decode()}}
+        )
+
+        import asyncio
+        asyncio.run(client._handle_message(msg))
+        assert received == [raw]
+
+    def test_context_created_sets_ready(self) -> None:
+        from app.ai.sixtydb_tts import SixtyDBTTSClient
+
+        client = SixtyDBTTSClient(api_key="k")
+        import asyncio
+        asyncio.run(client._handle_message(json.dumps({"context_created": {"context_id": "c"}})))
+        assert client._context_ready.is_set()
+
+
+class TestDeepgramSpeakRouting:
+    """DeepgramAgentClient behavior when 60db is the speak provider."""
+
+    def _client(self):
+        from app.ai.deepgram_agent import DeepgramAgentClient
+        return DeepgramAgentClient(
+            api_key="dg",
+            speak_provider="60db",
+            sixtydb_api_key="sk_live_test",
+            sixtydb_voice_id="voice-1",
+        )
+
+    def test_requires_sixtydb_key(self) -> None:
+        from app.ai.deepgram_agent import DeepgramAgentClient
+        with pytest.raises(ValueError):
+            DeepgramAgentClient(api_key="dg", speak_provider="60db", sixtydb_api_key="")
+
+    def test_creates_sixtydb_client(self) -> None:
+        client = self._client()
+        assert client._sixtydb is not None
+
+    def test_deepgram_binary_audio_ignored(self) -> None:
+        """In 60db mode, Deepgram's own TTS audio must not be queued."""
+        client = self._client()
+        import asyncio
+        asyncio.run(client._handle_binary_audio(b"\xff" * 160))
+        assert client._audio_queue.empty()
+
+    def test_greeting_not_sent_to_deepgram(self) -> None:
+        """Greeting is spoken by 60db, so it must not be in the Deepgram Settings."""
+        from app.ai.deepgram_agent import DeepgramAgentClient
+
+        sent: list[str] = []
+
+        class _FakeWS:
+            async def send(self, msg: str) -> None:
+                sent.append(msg)
+
+        client = DeepgramAgentClient(
+            api_key="dg",
+            speak_provider="60db",
+            sixtydb_api_key="sk_live_test",
+            greeting="Hello there!",
+        )
+        client._ws = _FakeWS()  # type: ignore[assignment]
+        import asyncio
+        asyncio.run(client._send_session_config())
+        agent_cfg = json.loads(sent[0])["agent"]
+        assert "greeting" not in agent_cfg
+
+    def test_sixtydb_audio_enqueued_as_pcm16(self) -> None:
+        """60db's mu-law chunks are converted to PCM16 and queued for the bridge."""
+        client = self._client()
+        raw_ulaw = b"\xff\x7f\x00\x10"
+        import asyncio
+        asyncio.run(client._enqueue_agent_audio(raw_ulaw))
+        queued = client._audio_queue.get_nowait()
+        assert queued == Codec.ulaw_to_pcm16(raw_ulaw)
+        assert client._received_first_audio is True
+        assert client._agent_speaking is True


### PR DESCRIPTION
A 60db voice option for the Deepgram agent. Set SPEAK_PROVIDER=60db (+ SIXTYDB_API_KEY, SIXTYDB_VOICE_ID) and Deepgram's replies  
  are spoken in a 60db voice instead of Deepgram's own. New: SixtyDBTTSClient (60db TTS WebSocket client), config wiring, a
  list_60db_voices.py helper, and tests. Default behavior is unchanged.
  
  How it works

  - Deepgram = brain: listens (STT), thinks (gpt-4o-mini), handles turn-taking, and emits the reply as text.
  - 60db = voice: we take that text and send it to 60db TTS (wss://api.60db.ai/ws/tts), configured for μ-law @ 8 kHz.
  - 60db streams back audio chunks → we decode them → feed them into the existing audio bridge → the caller hears the 60db voice.   
  - Deepgram's own audio is ignored; the greeting is spoken by 60db.

  Flow: caller speaks → Deepgram (STT + LLM) → reply text → 60db TTS → caller hears it.